### PR TITLE
TXMP-822 Pull python from docker registry, not ecr

### DIFF
--- a/Dockerfile.jenkins
+++ b/Dockerfile.jenkins
@@ -1,4 +1,4 @@
-FROM 727065427295.dkr.ecr.eu-west-2.amazonaws.com/lambda-build:latest
+FROM python:3.8.2
 
 # allow user and source root to be passed as args at default to sensibles
 ARG APP_USER=jenkins


### PR DESCRIPTION
## What
Changes the docker build image to pull from docker registry, not ECR

## Why
We were using ECR before because we erroneously believed that the jenkins nodes didn't have outside internet access. This was because the builds were taking place on the master node, once we configured the build to happen on the slaves, they can reach docker registry.

## How to review
Check that this builds on jenkins ([it does](https://jenkins.tools.txm/job/lambda-functions/job/txm-s3-log-shipper-lambda/1120/console))

## Who can review
Anyone but @wfaithfull 
