### PR TITLE
Set log level to INFO

### DIFF
--- a/handler.py
+++ b/handler.py
@@ -53,7 +53,7 @@ SHIPPER: RedisLogShipper = RedisLogShipper(REDIS, PARSER_MANAGER, S3_CLIENT)
 
 
 def log_handler(event: dict, context) -> None:
-    aws_lambda_logging.setup(level="DEBUG")
+    aws_lambda_logging.setup(level="INFO")
     log.info(event)
     s3_event: S3Event = S3Event.from_dict(event)
 


### PR DESCRIPTION
## What
Sets log level for the lambda to INFO

## Why
Not sure why this was set to DEBUG, although it recently became a problem when lambda logs started finding their way into telemetry stack.

## How to review
WITH YOUR EYES

https://gitlab.com/hadrien/aws_lambda_logging/-/blob/master/aws_lambda_logging.py

## Who can review
@scottcutts 